### PR TITLE
Reject a pet - user_story_14

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -8,7 +8,7 @@ class Admin::ApplicationsController < ApplicationController
   def update
     @application = Application.find(params[:id])
     pet_app = PetApplication.pet_app(@application.id, params[:petid])
-    pet_app.status = "1"
+    pet_app.status = params[:status]
     pet_app.save
     redirect_to "/admin/applications/#{@application.id}/"
   end

--- a/app/models/pet_application.rb
+++ b/app/models/pet_application.rb
@@ -2,7 +2,7 @@ class PetApplication < ApplicationRecord
   belongs_to :application
   belongs_to :pet
 
-  enum status: { "Open" => "0", "Closed" => "1" }
+  enum status: { "Open" => "0", "Approved" => "1", "Rejected" => "2"}
 
   def self.pet_app(applicationid,petid)
     PetApplication.where("application_id = ? and pet_id = ?", applicationid, petid).first

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -9,12 +9,23 @@
     <% if PetApplication.pet_app(@application.id,pet.id).status == "Open" %>
 
         <%= form_with url: "/admin/applications/#{@application.id}/?status=1", method: :patch, local: true do |f| %>
-          <button class="btn btn-success btn-secondary btn-sm" type="submit">Approve for Adoption</button>
+          <button class="btn btn-success btn-secondary btn-sm" type="submit">Approve</button>
           <%= f.text_field :petid, value: pet.id, hidden: true %>
-      <% end %>
-    <% else %>
+        <% end %>
+
+        <%= form_with url: "/admin/applications/#{@application.id}/?status=2", method: :patch,  local: true do |f| %>
+          <button class="btn btn-danger btn-secondary btn-sm" type="submit">Reject</button>
+          <%= f.text_field :petid, value: pet.id, hidden: true %>
+        <% end %>
+
+    <% elsif PetApplication.pet_app(@application.id,pet.id).status == "Approved" %>
       <ul>
         <h5><%= "This application has been approved!" %></h5>
+      </ul>
+
+    <% elsif PetApplication.pet_app(@application.id,pet.id).status == "Rejected" %>
+      <ul>
+        <h5><%= "This application has been rejected!" %></h5>
       </ul>
     <% end %>
 

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -23,9 +23,20 @@ RSpec.describe "Admin Applications Show Page" do
     visit "/admin/applications/#{@application.id}"
     expect(page).to have_content(@pet_1.name)
     expect(page).to have_content(@pet_2.name)
-    expect(page).to have_button("Approve for Adoption")
-    click_on("Approve for Adoption", match: :first)
+    expect(page).to have_button("Approve")
+    click_on("Approve", match: :first)
     expect(current_path).to eq("/admin/applications/#{@application.id}/")
     expect(page).to have_content("This application has been approved!")
+  end
+
+  it "displays a button to reject application for a pet" do
+    visit "/admin/applications/#{@application.id}"
+    expect(page).to have_content(@pet_1.name)
+    expect(page).to have_content(@pet_2.name)
+    expect(page).to have_button("Reject")
+    click_on("Reject", match: :first)
+    expect(current_path).to eq("/admin/applications/#{@application.id}/")
+    expect(page).to have_content("This application has been rejected!")
+    save_and_open_page
   end
 end


### PR DESCRIPTION
Each pet has a button to reject the application for that specific pet
After clicking that button
admin is taken back to the admin application show page
And next to the pet that was rejected, the admin does not see a button
And instead an indicator next to the pet that they have been rejected