### PR TITLE
Applications for same pet do not affect each other - user_story_13

### DIFF
--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -11,10 +11,16 @@ RSpec.describe "Admin Applications Show Page" do
       city: "Sandy Springs",
       state: "CO",
       zipcode: 12345)
+    @application2 = Application.create!(name: "Jerg",
+      street_address: "2 Blueberries",
+      city: "File Drive",
+      state: "CA",
+      zipcode: 54321)
     @pet_1 = Pet.create!(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: @shelter_4.id)
     @pet_2 = Pet.create!(adoptable: true, age: 3, breed: 'dragon', name: 'Blake C', shelter_id: @shelter_1.id)
     @pet_application = PetApplication.create!(application_id: @application.id, pet_id: @pet_1.id)
     @pet_application1 = PetApplication.create!(application_id: @application.id, pet_id: @pet_2.id)
+    @pet_application2 = PetApplication.create!(application_id: @application2.id, pet_id: @pet_1.id)
     @application.status = "1"
     @application.save
   end
@@ -37,6 +43,19 @@ RSpec.describe "Admin Applications Show Page" do
     click_on("Reject", match: :first)
     expect(current_path).to eq("/admin/applications/#{@application.id}/")
     expect(page).to have_content("This application has been rejected!")
-    save_and_open_page
+  end
+
+  it "displays a button to approve or reject application for a pet if there are two applications for the same pet" do
+    visit "/admin/applications/#{@application.id}"
+    expect(page).to have_content(@pet_1.name)
+    expect(page).to have_content(@pet_2.name)
+    expect(page).to have_button("Reject")
+    click_on("Reject", match: :first)
+    expect(current_path).to eq("/admin/applications/#{@application.id}/")
+    expect(page).to have_content("This application has been rejected!")
+    visit "/admin/applications/#{@application2.id}"
+    expect(page).to have_content(@pet_1.name)
+    expect(page).to have_button("Approve")
+    expect(page).to have_button("Reject")
   end
 end


### PR DESCRIPTION
When there are two applications in the system for the same pet
And the admin goes to the admin application show page for one of the applications
And approves or rejects the pet for that application

When admin visits the other application's admin show page
The admin does not see that the pet has been accepted or rejected for that application
And instead sees buttons to approve or reject the pet for this specific application